### PR TITLE
fixes multiple transactions

### DIFF
--- a/views/js/securesubmit.js
+++ b/views/js/securesubmit.js
@@ -15,7 +15,7 @@
 
   function bindHandler() {
     var button = $("#payment-confirmation div button.btn.btn-primary.center-block");
-    button.on("click", secureSubmitFormHandler);
+    button.off("click").on("click", secureSubmitFormHandler);
   }
 
   function secureSubmitFormHandler(event) {


### PR DESCRIPTION
Under certain circumstances, secureSubmitFormHandler could be bound
multiple times to the button click handler.  This would cause the transaction
to be submitted multiple times to Heartland and create duplicate orders
in Prestashop.  This fixes the issue by making sure the click handler is
only bound once.